### PR TITLE
fix: Corrects URL to source code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ on a 3D printer, and python source code for driving the machine.
 
 * [Bill of Materials](BOM.md)
 * [3D models](hw/)
-* [Source Code](sw/)
+* [Source Code](src/cutwire.py)


### PR DESCRIPTION
Chose to link to the .py directly as currently there is only one source code file

Would resolve Issue #2 if merged